### PR TITLE
[LOOKML-10] Add LintTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 
     <!-- Component and plugin versions, in alphabetical order. -->
     <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <calcite.version>1.36.0</calcite.version>
     <checkerframework.version>3.42.0</checkerframework.version>
     <!-- We support checkstyle 9.3 and higher; 10.0 requires JDK 11 or higher. -->
     <checkstyle.version>10.14.2</checkstyle.version>
@@ -113,6 +114,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.calcite</groupId>
+      <artifactId>calcite-core</artifactId>
+      <version>${calcite.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>

--- a/src/test/java/net/hydromatic/lookml/test/LintTest.java
+++ b/src/test/java/net/hydromatic/lookml/test/LintTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the LookML Authors under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.
+ * The LookML Authors license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package net.hydromatic.lookml.test;
+
+import org.apache.calcite.util.Puffin;
+import org.apache.calcite.util.Source;
+import org.apache.calcite.util.Sources;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+/** Runs Lint-like checks on the source code.
+ * Also tests those checks. */
+public class LintTest {
+  @SuppressWarnings("Convert2MethodRef") // JDK 8 requires lambdas
+  private Puffin.Program<GlobalState> makeProgram() {
+    return Puffin.builder(GlobalState::new, global -> new FileState(global))
+        .add(line -> line.isLast(),
+            line -> {
+              String f = line.filename();
+              final int slash = f.lastIndexOf('/');
+              final String endMarker =
+                  "// End " + (slash < 0 ? f : f.substring(slash + 1));
+              if (!line.line().equals(endMarker)
+                  && line.filename().endsWith(".java")) {
+                line.state().message("File must end with '" + endMarker + "'",
+                    line);
+              }
+            })
+        .add(line -> line.fnr() == 1,
+            line -> line.globalState().fileCount++)
+
+        // Trailing space
+        .add(line -> line.endsWith(" "),
+            line -> line.state().message("Trailing space", line))
+
+        // Tab
+        .add(line -> line.contains("\t"),
+            line -> line.state().message("Tab", line))
+
+        // Comment without space
+        .add(line -> line.matches(".* //[^ ].*")
+                && !line.source().fileOpt()
+                .filter(f -> f.getName().equals("LintTest.java")).isPresent()
+                && !line.contains("//--")
+                && !line.contains("//~")
+                && !line.contains("//noinspection")
+                && !line.contains("//CHECKSTYLE"),
+            line -> line.state().message("'//' must be followed by ' '", line))
+
+        // Javadoc does not require '</p>', so we do not allow '</p>'
+        .add(line -> line.state().inJavadoc()
+                && line.contains("</p>"),
+            line -> line.state().message("no '</p>'", line))
+
+        // No "**/"
+        .add(line -> line.contains(" **/")
+                && line.state().inJavadoc(),
+            line ->
+                line.state().message("no '**/'; use '*/'",
+                    line))
+
+        // A Javadoc paragraph '<p>' must not be on its own line.
+        .add(line -> line.matches("^ *\\* <p>"),
+            line ->
+                line.state().message("<p> must not be on its own line",
+                    line))
+
+        // A Javadoc paragraph '<p>' must be preceded by a blank Javadoc
+        // line.
+        .add(line -> line.matches("^ *\\*"),
+            line -> {
+              final FileState f = line.state();
+              if (f.starLine == line.fnr() - 1) {
+                f.message("duplicate empty line in javadoc", line);
+              }
+              f.starLine = line.fnr();
+            })
+        .add(line -> line.matches("^ *\\* <p>.*")
+                && line.fnr() - 1 != line.state().starLine,
+            line ->
+                line.state().message("<p> must be preceded by blank line",
+                    line))
+
+        // A non-blank line following a blank line must have a '<p>'
+        .add(line -> line.state().inJavadoc()
+                && line.state().ulCount == 0
+                && line.state().blockquoteCount == 0
+                && line.contains("* ")
+                && line.fnr() - 1 == line.state().starLine
+                && line.matches("^ *\\* [^<@].*"),
+            line -> line.state().message("missing '<p>'", line))
+
+        // The first "@param" of a javadoc block must be preceded by a blank
+        // line.
+        .add(line -> line.matches("^ */\\*\\*.*"),
+            line -> {
+              final FileState f = line.state();
+              f.javadocStartLine = line.fnr();
+              f.blockquoteCount = 0;
+              f.ulCount = 0;
+            })
+        .add(line -> line.matches(".*\\*/"),
+            line -> line.state().javadocEndLine = line.fnr())
+        .add(line -> line.matches("^ *\\* @.*"),
+            line -> {
+              if (line.state().inJavadoc()
+                  && line.state().atLine < line.state().javadocStartLine
+                  && line.fnr() - 1 != line.state().starLine) {
+                line.state().message(
+                    "First @tag must be preceded by blank line",
+                    line);
+              }
+              line.state().atLine = line.fnr();
+            })
+        .add(line -> line.contains("<blockquote>"),
+            line -> line.state().blockquoteCount++)
+        .add(line -> line.contains("</blockquote>"),
+            line -> line.state().blockquoteCount--)
+        .add(line -> line.contains("<ul>"),
+            line -> line.state().ulCount++)
+        .add(line -> line.contains("</ul>"),
+            line -> line.state().ulCount--)
+        .build();
+  }
+
+  /** Tests that source code has no flaws. */
+  @Test void testLint() {
+    Assumptions.assumeTrue(TestUnsafe.haveGit(), "Invalid git environment");
+
+    final Puffin.Program<GlobalState> program = makeProgram();
+    final List<File> javaFiles = TestUnsafe.getTextFiles();
+
+    final GlobalState g;
+    StringWriter b = new StringWriter();
+    try (PrintWriter pw = new PrintWriter(b)) {
+      g = program.execute(javaFiles.parallelStream().map(Sources::of), pw);
+    }
+
+    assertThat("Lint violations:\n" + b, g.messages, empty());
+  }
+
+  /** Warning that code is not as it should be. */
+  private static class Message {
+    final Source source;
+    final int line;
+    final String message;
+
+    Message(Source source, int line, String message) {
+      this.source = source;
+      this.line = line;
+      this.message = message;
+    }
+
+    @Override public String toString() {
+      return source + ":" + line + ":" + message;
+    }
+  }
+
+  /** Internal state of the lint rules. */
+  private static class GlobalState {
+    int fileCount = 0;
+    final List<Message> messages = new ArrayList<>();
+  }
+
+  /** Internal state of the lint rules, per file. */
+  private static class FileState {
+    final GlobalState global;
+    int starLine;
+    int atLine;
+    int javadocStartLine;
+    int javadocEndLine;
+    int blockquoteCount;
+    int ulCount;
+
+    FileState(GlobalState global) {
+      this.global = global;
+    }
+
+    void message(String message, Puffin.Line<GlobalState, FileState> line) {
+      global.messages.add(new Message(line.source(), line.fnr(), message));
+    }
+
+    public boolean inJavadoc() {
+      return javadocEndLine < javadocStartLine;
+    }
+  }
+}
+
+// End LintTest.java

--- a/src/test/java/net/hydromatic/lookml/test/TestUnsafe.java
+++ b/src/test/java/net/hydromatic/lookml/test/TestUnsafe.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the LookML Authors under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.
+ * The LookML Authors license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package net.hydromatic.lookml.test;
+
+import com.google.common.collect.ImmutableList;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+/**
+ * Unsafe methods to be used by tests.
+ *
+ * <p>Contains methods that call JDK methods that the
+ * <a href="https://github.com/policeman-tools/forbidden-apis">forbidden
+ * APIs checker</a> does not approve of.
+ *
+ * <p>This class is excluded from the check, so methods called via this class
+ * will not fail the build.
+ */
+public class TestUnsafe {
+  private TestUnsafe() {}
+
+  /**
+   * Runs an external application process.
+   *
+   * @param argumentList  command name and its arguments
+   * @param directory  working directory
+   * @param logger    if not null, command and exit status will be logged here
+   * @param appInput  if not null, data will be copied to application's stdin
+   * @param appOutput if not null, data will be captured from application's
+   *                  stdout and stderr
+   * @return application process exit value
+   */
+  public static int runAppProcess(List<String> argumentList, File directory,
+      @Nullable Logger logger, @Nullable Reader appInput,
+      @Nullable Writer appOutput) throws IOException, InterruptedException {
+
+    // WARNING: ProcessBuilder is security-sensitive. Its use is currently
+    // safe because this code is under "core/test". Developers must not move
+    // this code into "core/main".
+    final ProcessBuilder pb = new ProcessBuilder(argumentList);
+    pb.directory(directory);
+    pb.redirectErrorStream(true);
+    if (logger != null) {
+      logger.info("start process: " + pb.command());
+    }
+    Process p = pb.start();
+
+    // Setup the input/output streams to the subprocess.
+    // The buffering here is arbitrary. Javadocs strongly encourage
+    // buffering, but the size needed is very dependent on the
+    // specific application being run, the size of the input
+    // provided by the caller, and the amount of output expected.
+    // Since this method is currently used only by unit tests,
+    // large-ish fixed buffer sizes have been chosen. If this
+    // method becomes used for something in production, it might
+    // be better to have the caller provide them as arguments.
+    if (appInput != null) {
+      OutputStream out =
+          new BufferedOutputStream(
+              p.getOutputStream(),
+              100 * 1024);
+      int c;
+      while ((c = appInput.read()) != -1) {
+        out.write(c);
+      }
+      out.flush();
+    }
+    if (appOutput != null) {
+      InputStream in =
+          new BufferedInputStream(
+              p.getInputStream(),
+              100 * 1024);
+      int c;
+      while ((c = in.read()) != -1) {
+        appOutput.write(c);
+      }
+      appOutput.flush();
+      in.close();
+    }
+    p.waitFor();
+
+    int status = p.exitValue();
+    if (logger != null) {
+      logger.info("exit status=" + status + " from " + pb.command());
+    }
+    return status;
+  }
+
+  /** Returns whether we seem are in a valid environment. */
+  public static boolean haveGit() {
+    // Is there a '.git' directory? If not, we may be in a source tree
+    // unzipped from a tarball.
+    final File base = Tests.getBaseDir(TestUnsafe.class);
+    final File gitDir = new File(base, ".git");
+    if (!gitDir.exists()
+        || !gitDir.isDirectory()
+        || !gitDir.canRead()) {
+      return false;
+    }
+
+    // Execute a simple git command. If it fails, we're probably not in a
+    // valid git environment.
+    final List<String> argumentList =
+        ImmutableList.of("git", "--version");
+    try {
+      final StringWriter sw = new StringWriter();
+      int status =
+          runAppProcess(argumentList, base, null, null, sw);
+      final String s = sw.toString();
+      if (status != 0) {
+        return false;
+      }
+    } catch (Exception e) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Returns a list of Java files in git. */
+  public static List<File> getJavaFiles() {
+    return getGitFiles("*.java");
+  }
+
+  /** Returns a list of text files in git. */
+  public static List<File> getTextFiles() {
+    return getGitFiles("*.java", "*.jj", "*.md", "*.properties",
+        "*.sh", "*.sml", "*.smli", "*.txt", "*.xml", "*.yml");
+  }
+
+  /** Returns a list of files in git matching a given pattern or patterns.
+   *
+   * <p>Assumes running Linux or macOS, and that git is available. */
+  public static List<File> getGitFiles(String... patterns) {
+    String s;
+    try {
+      final List<String> argumentList =
+          ImmutableList.<String>builder().add("git").add("ls-files")
+              .add(patterns).build();
+      final File base = Tests.getBaseDir(TestUnsafe.class);
+      try {
+        final StringWriter sw = new StringWriter();
+        int status =
+            runAppProcess(argumentList, base, null, null, sw);
+        if (status != 0) {
+          throw new RuntimeException("command " + argumentList
+              + ": exited with status " + status);
+        }
+        s = sw.toString();
+      } catch (Exception e) {
+        throw new RuntimeException("command " + argumentList
+            + ": failed with exception", e);
+      }
+
+      final ImmutableList.Builder<File> files = ImmutableList.builder();
+      try (StringReader r = new StringReader(s);
+           BufferedReader br = new BufferedReader(r)) {
+        for (;;) {
+          String line = br.readLine();
+          if (line == null) {
+            break;
+          }
+          files.add(new File(base, line));
+        }
+      }
+      return files.build();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Returns the subject / body pairs of the {@code n} most recent commits. */
+  public static void getCommitMessages(int n,
+      BiConsumer<String, String> consumer) {
+    // Generate log like this:
+    //
+    //   ===
+    //   subject
+    //
+    //   body
+    //   ===
+    //   subject 2
+    //
+    //   body2
+    //
+    // then split on "===\n"
+    final File base = Tests.getBaseDir(TestUnsafe.class);
+    final List<String> argumentList =
+        ImmutableList.of("git", "log", "-n" + n, "--pretty=format:===%n%B");
+    try {
+      final StringWriter sw = new StringWriter();
+      int status =
+          runAppProcess(argumentList, base, null, null, sw);
+      String s = sw.toString();
+      if (status != 0) {
+        throw new RuntimeException("command " + argumentList
+            + ": exited with status " + status
+            + (s.isEmpty() ? "" : "; output [" + s + "]"));
+      }
+      Stream.of(s.split("===\n")).forEach(s2 -> {
+        if (s2.isEmpty()) {
+          return; // ignore empty subject & body
+        }
+        int i = s2.indexOf("\n");
+        if (i < 0) {
+          i = s2.length(); // no linefeed; treat entire chunk as subject
+        }
+        String subject = s2.substring(0, i);
+        while (i < s2.length() && s2.charAt(i) == '\n') {
+          ++i; // skip multiple linefeeds between subject and body
+        }
+        String body = s2.substring(i);
+        consumer.accept(subject, body);
+      });
+    } catch (Exception e) {
+      throw new RuntimeException("command " + argumentList
+          + ": failed with exception", e);
+    }
+  }
+}
+
+// End TestUnsafe.java

--- a/src/test/java/net/hydromatic/lookml/test/Tests.java
+++ b/src/test/java/net/hydromatic/lookml/test/Tests.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the LookML Authors under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.
+ * The LookML Authors license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package net.hydromatic.lookml.test;
+
+import org.apache.calcite.util.Sources;
+
+import java.io.File;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Static utilities for JUnit tests.
+ */
+public class Tests {
+  private Tests() {}
+
+  /** Returns the root directory of the source tree. */
+  public static File getBaseDir(Class<?> klass) {
+    // Algorithm:
+    // 1) Find location of TestUtil.class
+    // 2) Climb via getParentFile() until we detect pom.xml
+    // 3) It means we've got BASE/testkit/pom.xml, and we need to get BASE
+    final URL resource = klass.getResource(klass.getSimpleName() + ".class");
+    final File classFile =
+        Sources.of(requireNonNull(resource, "resource")).file();
+
+    File file = classFile.getAbsoluteFile();
+    for (int i = 0; i < 42; i++) {
+      if (isProjectDir(file)) {
+        // Ok, file == BASE/testkit/
+        break;
+      }
+      file = file.getParentFile();
+    }
+    if (!isProjectDir(file)) {
+      fail("Could not find pom.xml, build.gradle.kts or gradle.properties. "
+          + "Started with " + classFile.getAbsolutePath()
+          + ", the current path is " + file.getAbsolutePath());
+    }
+    return file;
+  }
+
+  private static boolean isProjectDir(File dir) {
+    return new File(dir, "pom.xml").isFile()
+        || new File(dir, "build.gradle.kts").isFile()
+        || new File(dir, "gradle.properties").isFile();
+  }
+}
+
+// End Tests.java


### PR DESCRIPTION
A test that applies various lint rules (powered by Puffin, a scripting language inspired by Awk) will allow the project to enforce whatever coding policies we decide on.

LintTest, Tests and TestUnsafe are copied from code that I wrote in Morel.

LintTest is powered by Puffin, so we add Apache Calcite as a test dependency.

Fixes #10